### PR TITLE
Error in array with '[]'

### DIFF
--- a/Lesson4/alecaddd-plugin.php
+++ b/Lesson4/alecaddd-plugin.php
@@ -57,7 +57,7 @@ class AlecadddPlugin
 	}
 
 	function custom_post_type() {
-		register_post_type( 'book', ['public' => true, 'label' => 'Books'] );
+		register_post_type( 'book', array( 'public' => true, 'label' => 'Books' ) );
 	}
 }
 


### PR DESCRIPTION
Error returned due to square brackets: Plugin could not be activated because it triggered a fatal error.